### PR TITLE
Update to be safe for PEAR

### DIFF
--- a/dev_docs/config/dev_docs.php
+++ b/dev_docs/config/dev_docs.php
@@ -1,1 +1,1 @@
-<?php require('config.php');
+<?php require(dirname(__FILE__) . '/config.php');


### PR DESCRIPTION
On (some) systems with PEAR in the path, require(config.php) fatal errors because it tries to call the PEAR version. Changed to use explicit path: require(dirname(**FILE**) . '/config.php');
